### PR TITLE
updated connection management to fix stuck connections

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/NarrativeScience/cookiecutter-python-lib",
-  "commit": "988b5b8439e2e149c4d3b1e32293b048bf975226",
+  "commit": "f31f5912ab949296517c6d65fc666b11926a5cf8",
   "context": {
     "cookiecutter": {
       "author_name": "",

--- a/pynocular/__init__.py
+++ b/pynocular/__init__.py
@@ -1,6 +1,6 @@
 """Lightweight ORM that lets you query your database using Pydantic models and asyncio"""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"
 
 from pynocular.database_model import DatabaseModel, UUID_STR
 from pynocular.engines import DatabaseType, DBInfo

--- a/pynocular/aiopg_transaction.py
+++ b/pynocular/aiopg_transaction.py
@@ -166,11 +166,8 @@ class transaction:
         # If we have started a transaction, store it here
         self._trx = None
 
-        # Initiatize an interface for managing the connection on the asyncio task context.
-        # Since we want one unique connection per process we are using the engine's dsn which
-        # is a string repr of the username, password(redacted), hostname, port and db name that
-        # the engine is connected to
-        self.task_connection = TaskContextConnection(engine.dsn)
+        # Initiatize an interface for managing the connection on the asyncio task context
+        self.task_connection = TaskContextConnection(str(engine))
 
     async def __aenter__(self) -> LockedConnection:
         """Establish the transaction context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pynocular"
-version = "0.16.0"
+version = "0.17.0"
 description = "Lightweight ORM that lets you query your database using Pydantic models and asyncio"
 authors = [
   "RJ Santana <ssantana@narrativescience.com>",

--- a/tests/functional/test_transactions.py
+++ b/tests/functional/test_transactions.py
@@ -71,7 +71,7 @@ class TestDatabaseTransactions:
         loop.run_until_complete(cls._teardown_class())
 
     @pytest.mark.asyncio
-    async def test_gathered_updates(self) -> None:
+    async def test_gathered_creates(self) -> None:
         """Test that we can update the db multiple times in a gather under a single transaction"""
         try:
             async with await DBEngine.transaction(testdb, is_conditional=False):

--- a/tests/unit/test_task_context_connection.py
+++ b/tests/unit/test_task_context_connection.py
@@ -1,0 +1,49 @@
+"""Test for TaskContextConnection"""
+from unittest.mock import Mock
+
+import pytest
+
+from pynocular.aiopg_transaction import LockedConnection, TaskContextConnection
+
+
+@pytest.fixture()
+def locked_connection():
+    """Return a locked connection"""
+    return LockedConnection(Mock())
+
+
+@pytest.mark.asyncio()
+async def test_task_context_connection_set_clear(locked_connection) -> None:
+    """Test that we can set and clear the connection"""
+
+    context_conn = TaskContextConnection("key1")
+    context_conn.set(locked_connection)
+    test_conn = context_conn.get()
+    assert test_conn == locked_connection
+
+    context_conn.clear()
+    # No connection should exist now
+    test_conn = context_conn.get()
+    assert test_conn is None
+
+
+@pytest.mark.asyncio()
+async def test_task_context_connection_shared(locked_connection) -> None:
+    """Test that we can share context across instances"""
+
+    context_conn = TaskContextConnection("key1")
+    context_conn.set(locked_connection)
+    test_conn = context_conn.get()
+    assert test_conn == locked_connection
+
+    # Create another instance that should share the connection
+    context_conn2 = TaskContextConnection("key1")
+    test_conn2 = context_conn2.get()
+    assert test_conn2 == locked_connection
+
+    context_conn.clear()
+    # No connection should exist on either connection
+    test_conn = context_conn.get()
+    assert test_conn is None
+    test_conn2 = context_conn2.get()
+    assert test_conn2 is None


### PR DESCRIPTION
# Overview of changes
There was an issue with old connections sticking around. This was due to the fact that we were using a default `{}` in the ContextVar and it wasn't getting properly cleaned up with `reset`. 

## For software test
N/A