### PR TITLE
LEXIO-37621: extend patch_database_model to handle other operators

### DIFF
--- a/pynocular/__init__.py
+++ b/pynocular/__init__.py
@@ -1,6 +1,6 @@
 """Lightweight ORM that lets you query your database using Pydantic models and asyncio"""
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 from pynocular.database_model import DatabaseModel, UUID_STR
 from pynocular.engines import DatabaseType, DBInfo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pynocular"
-version = "0.17.0"
+version = "0.18.0"
 description = "Lightweight ORM that lets you query your database using Pydantic models and asyncio"
 authors = [
   "RJ Santana <ssantana@narrativescience.com>",


### PR DESCRIPTION
# Overview of changes
Extends `patch_database_model` to support a few new cases
- `!=` operator
- `~` operator
- `update()` class method
- the `or_(*args)` opeartor (where `len(args) > 2`)

## For software test
N/A
